### PR TITLE
Fixes a weird search behavior

### DIFF
--- a/pyjobs_web/pyjobsweb/controllers/jobs.py
+++ b/pyjobs_web/pyjobsweb/controllers/jobs.py
@@ -135,6 +135,7 @@ class SearchJobsController(BaseController):
             redirect('/jobs')
 
         search_query = JobElastic().search()
+        relevance_sort = sort_by == 'score'
 
         if query:
             keyword_queries = self._compute_keyword_queries(query)
@@ -145,6 +146,8 @@ class SearchJobsController(BaseController):
                 query=keyword_queries,
                 functions=decay_functions
             )
+        else:
+            relevance_sort = False
 
         try:
             geoloc_query = json.loads(center)
@@ -161,7 +164,9 @@ class SearchJobsController(BaseController):
             search_query = self._apply_geolocation_filters(
                 search_query, (lat, lon), radius if radius else 5.0)
 
-        if sort_by == 'dates':
+        date_sort = not relevance_sort
+
+        if date_sort:
             search_query = self._apply_date_sort(search_query)
 
         return dict(sources=SOURCES, jobs=PaginatedSearch(search_query),

--- a/pyjobs_web/pyjobsweb/controllers/jobs.py
+++ b/pyjobs_web/pyjobsweb/controllers/jobs.py
@@ -135,7 +135,7 @@ class SearchJobsController(BaseController):
             redirect('/jobs')
 
         search_query = JobElastic().search()
-        relevance_sort = sort_by == 'score'
+        relevance_sort = sort_by == 'scores'
 
         if query:
             keyword_queries = self._compute_keyword_queries(query)


### PR DESCRIPTION
When applying a geolocation filter but no keywords filters, the results were still being sorted by scores by Elasticsearch, which would result in weirdly sorted job offers. The default expected behavior for a user looking for job offers would be to have them sorted by dates if if he's not looking for specific keywords. This new sort has been implemented in this request.